### PR TITLE
remove unneeded type from css and js in HTML

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -22,9 +22,9 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link href="https://fonts.googleapis.com/css?family=Lobster" rel="stylesheet">
     <!--Import materialize.css-->
-    <link type="text/css" rel="stylesheet" href="vendor/materialize/css/materialize{{useMinified}}.css"  media="screen,projection"/>
+    <link rel="stylesheet" href="vendor/materialize/css/materialize{{useMinified}}.css"  media="screen,projection"/>
     <!-- Custom -->
-    <link rel="stylesheet" type="text/css" href="css/{{bundleVersion}}/style.css">
+    <link rel="stylesheet" href="css/{{bundleVersion}}/style.css">
   </head>
   <body>
     <section class="row header section">
@@ -449,7 +449,7 @@
       </div>
     </div>
     {{devBanner}}
-    <script type="text/javascript" src="vendor/materialize/js/materialize{{useMinified}}.js"></script>
+    <script src="vendor/materialize/js/materialize{{useMinified}}.js"></script>
     <script src='js/main.bundle-{{bundleVersion}}.js'></script>
   </body>
 </html>


### PR DESCRIPTION
These are not needed and removing makes page a few bytes lighter.